### PR TITLE
Organize training outputs: launch parameters, training logs, and checkpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,5 @@
-/outputs/
+/experiment_output/
 /data_temp/
-/logs/
-/checkpoints/
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ Modify `configs/config.yaml` or override via CLI. See for more details: https://
 - [x] Setup tests
 - [x] Setup dependabot
 - [x] Add logger
+- [x] Organize `logs/`, `checkpoints/` (Lightning), and `outputs/` (Hydra) properly
 
 ## 📝 TODO List
 
@@ -99,9 +100,9 @@ Modify `configs/config.yaml` or override via CLI. See for more details: https://
 - [ ] 🏆 Evaluation script
 - [ ] 🛠 Hyperparameter tuning with Optuna
 - [ ] 🚀 Check Multi-GPU
+- [ ] ⚡ Add more Lightning Trainer features (resume, callbacks, etc.)
 - [ ] 📈 MLflow and/or Wandb
 - [ ] 🐳 Docker support for easy deployment
-- [ ] 📂 Organize `logs/`, `checkpoints/` (Lightning), and `outputs/` (Hydra) properly
 
 ## 📜 License
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,6 @@ lightning-hydra-boilerplate/
 │   │   │   ├── lightning_module.py
 │   │   │   ├── torch_model.py
 │   ├── utils/
-│   │   ├── hydra_utils.py
 │   ├── train.py               # Training entrypoint
 │
 │── tests/                     # Unit tests
@@ -74,10 +73,16 @@ You can override configs using Hydra, for example:
 All experiment settings are managed with Hydra.
 Modify `configs/config.yaml` or override via CLI. See for more details: https://hydra.cc/docs/intro/
 
-### **4️⃣ Logging**
+### **4️⃣ Outputs**
 
-- Training logs are saved using **TensorBoard** by default. Logs can be found in `logs/`.
-- Hydra stores experiment outputs, including config snapshots, in the `outputs/` directory.
+- **Training logs** (using **TensorBoard** by default) can be found in:
+  `experiment_output/{experiment_name}-{timestamp}/logs/`.
+
+- **Hydra** stores experiment outputs, including config snapshots, in:
+  `experiment_output/{experiment_name}-{timestamp}/.hydra/`.
+
+- **Checkpoints** (including both best and last models) are saved in:
+  `experiment_output/{experiment_name}-{timestamp}/checkpoints/`.
 
 ## ✅ Completed Tasks
 

--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -6,3 +6,8 @@ defaults:
 
 seed: 42
 skip_test: False
+experiment_name: "exp"
+
+hydra:
+  run:
+    dir: "experiment_output/${experiment_name}-${now:%Y-%m-%d_%H-%M-%S}"

--- a/configs/trainer/default.yaml
+++ b/configs/trainer/default.yaml
@@ -2,7 +2,7 @@ max_epochs: 10
 devices: 1
 logger:
   _target_: lightning.pytorch.loggers.TensorBoardLogger
-  save_dir: "logs/"
+  save_dir: "${hydra:run.dir}/logs/"
 callbacks:
   - _target_: lightning.pytorch.callbacks.EarlyStopping
     monitor: "val_loss"
@@ -10,7 +10,7 @@ callbacks:
     patience: 3
     verbose: true
   - _target_: lightning.pytorch.callbacks.ModelCheckpoint
-    dirpath: "checkpoints"
+    dirpath: "${hydra:run.dir}/checkpoints"
     filename: "best-checkpoint"
     monitor: "val_loss"
     mode: "min"


### PR DESCRIPTION
This PR organizes training outputs into a single directory. Additionally, the experiment_name configuration is added to facilitate the management and separation of each experiment's results by name.


# Screenshot

![image](https://github.com/user-attachments/assets/13b916a4-ccce-4e05-96d3-c37b74d1088f)
