### PR TITLE
Clean up evaluation logic and restrict to val/test splits

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ This will:
 
 ### **3️⃣ Evaluate a Model**
 
-If you need to run evaluation independently on a specific checkpoint and dataset split (train, val, or test), use the evaluation script:
+If you need to run evaluation independently on a specific checkpoint and dataset split (val or test), use the evaluation script:
 
 ```bash
 poetry run python src/eval.py eval_split=test ckpt_path=/path/to/checkpoint.ckpt
@@ -137,6 +137,7 @@ More info: https://hydra.cc/docs/intro/
 - [ ] MLflow and/or Wandb
 - [ ] Docker support for easy deployment
 - [ ] Make metrics configurable
+- [ ] Add task-specific examples and configs (e.g., object detection, text classification, etc.)
 
 ## 📜 License
 

--- a/configs/eval.yaml
+++ b/configs/eval.yaml
@@ -5,7 +5,7 @@ defaults:
 
 experiment_name: "eval"
 ckpt_path: ??? # User must override this
-eval_split: "test" # one of: test, val, train
+eval_split: "test" # one of: test or val
 
 hydra:
   run:

--- a/src/eval.py
+++ b/src/eval.py
@@ -33,21 +33,18 @@ def evaluate(cfg: DictConfig) -> None:
     ckpt_path = cfg.ckpt_path
 
     if eval_split == "test":
-        dataloader = datamodule.test_dataloader()
+        dataset = datamodule.test_dataloader().dataset
         split_name = "Test"
+        results = trainer.test(model=model, datamodule=datamodule, ckpt_path=ckpt_path)
     elif eval_split == "val":
-        dataloader = datamodule.val_dataloader()
+        dataset = datamodule.val_dataloader().dataset
         split_name = "Validation"
-    elif eval_split == "train":
-        dataloader = datamodule.train_dataloader()
-        split_name = "Training"
+        results = trainer.validate(model=model, datamodule=datamodule, ckpt_path=ckpt_path)
     else:
         error_msg = f"Unknown eval_split: {eval_split}"
         raise ValueError(error_msg)
 
-    logging.info(f"{split_name} dataset size: {len(dataloader.dataset)}")
-    results = trainer.validate(model=model, dataloaders=dataloader, ckpt_path=ckpt_path)
-
+    logging.info(f"{split_name} dataset size: {len(dataset)}")
     logging.info(f"Evaluation results on {split_name} set:\n{results}")
 
 


### PR DESCRIPTION
This PR cleans up the evaluation script by simplifying the logic and restricting evaluation to only the `val` and `test` splits.

## Motivation

Evaluating on the training set via Trainer.validate() previously caused confusion, as it reuses the `validation_step`, which logs metrics under "val_loss" and "val_acc", even when running on the train set. This led to misleading or inconsistent logging. To keep the behavior clean and intuitive, as of now, the train split is no longer supported for standalone evaluation.