### PR TITLE
Add inference script and save predictions to file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
-/train_output/
-/eval_output/
+/outputs/
 /data_temp/
 
 # Byte-compiled / optimized / DLL files

--- a/README.md
+++ b/README.md
@@ -75,10 +75,23 @@ This will:
 If you need to run evaluation independently on a specific checkpoint and dataset split (val or test), use the evaluation script:
 
 ```bash
-poetry run python src/eval.py eval_split=test ckpt_path=/path/to/checkpoint.ckpt
+poetry run python src/eval.py data_split=test ckpt_path=/path/to/checkpoint.ckpt
 ```
 
-### **4️⃣ Experiment Configuration**
+### **4️⃣ Predict Outputs**
+
+To generate predictions from a trained model (e.g., for submission or analysis), run the predict.py script with the path to your checkpoint:
+
+```bash
+poetry run python src/predict.py ckpt_path=/path/to/checkpoint.ckpt
+```
+
+This will:
+
+- Run inference on the prediction set (defaults to `test` set)
+- Save the results to a file (e.g., predictions.csv or predictions.json depending on `save_format`) under the Hydra run directory
+
+### **5️⃣ Experiment Configuration**
 
 All experiment settings are managed with Hydra.
 
@@ -90,26 +103,18 @@ You can modify the configs under configs/ or override them via CLI. For example:
 
 More info: https://hydra.cc/docs/intro/
 
-### **5️⃣ Outputs**
+### **6️⃣ Outputs**
 
-#### 🏋️ Training Outputs
+All run outputs are saved under the `outputs/` directory:
 
-- Training logs (via TensorBoard by default):
-  `train_output/{experiment_name}-{timestamp}/logs/`.
+```plaintext
+outputs/
+├── train/    ← training logs, checkpoints, config snapshots
+├── eval/     ← evaluation logs and results
+├── predict/  ← prediction files (e.g. .csv, .json)
+```
 
-- Hydra configuration snapshots:
-  `train_output/{experiment_name}-{timestamp}/.hydra/`.
-
-- Checkpoints:
-  `train_output/{experiment_name}-{timestamp}/checkpoints/`.
-
-#### 📈 Evaluation Outputs
-
-- Evaluation logs (via TensorBoard by default):
-  `eval_output/{experiment_name}-{timestamp}/logs/`.
-
-- Hydra configuration snapshots:
-  `eval_output/{experiment_name}-{timestamp}/.hydra/`.
+Each run is timestamped for easy tracking and reproducibility.
 
 ## ✅ Completed Tasks
 
@@ -124,13 +129,13 @@ More info: https://hydra.cc/docs/intro/
 - [x] Setup dependabot
 - [x] Add logger
 - [x] Organize `logs/`, `checkpoints/` (Lightning), and `outputs/` (Hydra) properly
-- [x] Evaluation script
+- [x] Evaluation script (`eval.py`)
+- [x] Inference script (`predict.py`)
 
 ## 📝 TODO List
 
 ⚠️ _Feel free to fork the repo, create a PR, or open an issue if you spot anything or have ideas. I’d love to hear your feedback and make this more useful for everyone!_
 
-- [ ] Inference script
 - [ ] Hyperparameter tuning with Optuna
 - [ ] Check Multi-GPU
 - [ ] Add more Lightning Trainer features (resume, callbacks, etc.)

--- a/configs/eval.yaml
+++ b/configs/eval.yaml
@@ -5,8 +5,8 @@ defaults:
 
 experiment_name: "eval"
 ckpt_path: ??? # User must override this
-eval_split: "test" # one of: test or val
+data_split: "test" # one of: test or val
 
 hydra:
   run:
-    dir: "eval_output/${experiment_name}-${now:%Y-%m-%d_%H-%M-%S}"
+    dir: "outputs/eval/${experiment_name}-${now:%Y-%m-%d_%H-%M-%S}"

--- a/configs/predict.yaml
+++ b/configs/predict.yaml
@@ -1,0 +1,13 @@
+defaults:
+  - model: example_model
+  - data: example_data
+  - trainer: default
+
+experiment_name: "predict"
+ckpt_path: ??? # User must override this
+data_split: "test" # one of: train, test, val, or predict
+save_format: csv # json or csv
+
+hydra:
+  run:
+    dir: "outputs/predict/${experiment_name}-${now:%Y-%m-%d_%H-%M-%S}"

--- a/configs/train.yaml
+++ b/configs/train.yaml
@@ -10,4 +10,4 @@ experiment_name: "exp"
 
 hydra:
   run:
-    dir: "train_output/${experiment_name}-${now:%Y-%m-%d_%H-%M-%S}"
+    dir: "outputs/train/${experiment_name}-${now:%Y-%m-%d_%H-%M-%S}"

--- a/src/data/example_data/lightning_datamodule.py
+++ b/src/data/example_data/lightning_datamodule.py
@@ -72,7 +72,7 @@ class ExampleDataModule(LightningDataModule):
 
         In this simple implementation, we use the same `test_dataset` for both testing
         and prediction purposes. This can be extended in the future to use a different
-        dataset for inference if needed.
+        dataset or unlabeled data for inference if needed.
         """
         return DataLoader(
             self.test_dataset,

--- a/src/data/example_data/torch_dataset.py
+++ b/src/data/example_data/torch_dataset.py
@@ -33,14 +33,14 @@ class ExampleTorchDataset(Dataset):
         """Return the number of samples in the dataset."""
         return len(self.dataset)
 
-    def __getitem__(self, idx: int) -> tuple[object, int]:
-        """Retrieve a single (image, label) pair by index.
+    def __getitem__(self, idx: int) -> tuple[int, object, int]:
+        """Retrieve a single (image, label, index) triplet by index.
 
         Args:
             idx (int): Index of the sample to retrieve.
 
         Returns:
-            Tuple[Tensor, int]: Tuple of image tensor and its corresponding label.
+            Tuple: (image, label, idx)
         """
         image, label = self.dataset[idx]
-        return image, label
+        return image, label, idx

--- a/src/eval.py
+++ b/src/eval.py
@@ -29,19 +29,19 @@ def evaluate(cfg: DictConfig) -> None:
     trainer = pl.Trainer(**trainer_params)
     datamodule.setup()
 
-    eval_split = cfg.eval_split
+    data_split = cfg.data_split
     ckpt_path = cfg.ckpt_path
 
-    if eval_split == "test":
+    if data_split == "test":
         dataset = datamodule.test_dataloader().dataset
         split_name = "Test"
         results = trainer.test(model=model, datamodule=datamodule, ckpt_path=ckpt_path)
-    elif eval_split == "val":
+    elif data_split == "val":
         dataset = datamodule.val_dataloader().dataset
         split_name = "Validation"
         results = trainer.validate(model=model, datamodule=datamodule, ckpt_path=ckpt_path)
     else:
-        error_msg = f"Unknown eval_split: {eval_split}"
+        error_msg = f"Unknown data_split: {data_split}"
         raise ValueError(error_msg)
 
     logging.info(f"{split_name} dataset size: {len(dataset)}")

--- a/src/predict.py
+++ b/src/predict.py
@@ -1,0 +1,77 @@
+# Copyright (c) 2025 lightning-hydra-boilerplate
+# Licensed under the MIT License.
+
+"""Inference script to generate and save model predictions."""
+
+import logging
+from pathlib import Path
+
+import hydra
+import lightning.pytorch as pl
+from hydra.core.hydra_config import HydraConfig
+from hydra.utils import instantiate
+from omegaconf import DictConfig, OmegaConf
+
+from utils.hydra_utils import instantiate_recursively
+from utils.logger_utils import setup_logger
+from utils.pred_utils import save_predictions
+
+
+def predict(cfg: DictConfig) -> None:
+    """Run inference on a specified data split using a trained model from a checkpoint.
+
+    Args:
+        cfg (DictConfig): Hydra configuration object containing model, data, and trainer settings.
+    """
+    logging.info("Running prediction with configuration:\n%s", OmegaConf.to_yaml(cfg))
+
+    model = instantiate(cfg.model)
+    datamodule = instantiate(cfg.data)
+    trainer_params = instantiate_recursively(cfg.trainer)
+    trainer = pl.Trainer(**trainer_params)
+
+    datamodule.setup()
+
+    # Select appropriate dataloader
+    if cfg.data_split == "train":
+        dataloader = datamodule.train_dataloader()
+    elif cfg.data_split == "val":
+        dataloader = datamodule.val_dataloader()
+    elif cfg.data_split == "test":
+        dataloader = datamodule.test_dataloader()
+    elif cfg.data_split == "predict":
+        dataloader = datamodule.predict_dataloader()
+    else:
+        error_msg = f"Unsupported data_split: {cfg.data_split}"
+        raise ValueError(error_msg)
+
+    predictions_batches = trainer.predict(
+        model=model,
+        dataloaders=dataloader,
+        ckpt_path=cfg.get("ckpt_path", None),
+    )
+    # Flatten and sort predictions by idx
+    flat_preds = [
+        {"idx": batch["idx"][i].item(), "pred": batch["pred"][i].item()}
+        for batch in predictions_batches
+        for i in range(len(batch["idx"]))
+    ]
+
+    flat_preds.sort(key=lambda x: x["idx"])
+
+    # Save the predictions
+    run_dir = HydraConfig.get().run.dir
+    output_path = Path(run_dir) / f"predictions.{cfg.save_format}"
+    save_predictions(flat_preds, output_path, cfg.save_format)
+    logging.info(f"Predictions of {cfg.data_split} split are saved to {output_path}")
+
+
+@hydra.main(version_base=None, config_path="../configs", config_name="predict")
+def main(cfg: DictConfig) -> None:
+    """Main prediction entry point triggered by Hydra config."""
+    setup_logger()
+    predict(cfg)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/train.py
+++ b/src/train.py
@@ -53,6 +53,7 @@ def train(cfg: DictConfig) -> None:
 @hydra.main(version_base=None, config_path="../configs", config_name="train")
 def main(cfg: DictConfig) -> None:
     """Main entry point, triggered by Hydra with config injection."""
+    pl.seed_everything(cfg.seed)
     setup_logger()
     train(cfg)
 

--- a/src/utils/pred_utils.py
+++ b/src/utils/pred_utils.py
@@ -1,0 +1,33 @@
+# Copyright (c) 2025 lightning-hydra-boilerplate
+# Licensed under the MIT License.
+
+"""Prediction utilities."""
+
+import csv
+import json
+from pathlib import Path
+
+
+def save_predictions(predictions: list[dict], output_path: Path, save_format: str = "json") -> None:
+    """Save predictions to a file in the specified format.
+
+    Args:
+        predictions (list[dict]): A list of prediction dictionaries.
+        output_path (Path): Path to the output file.
+        save_format (str): Format to save (json or csv).
+    """
+    if save_format not in {"json", "csv"}:
+        error_msg = f"Unsupported save_format: {save_format}"
+        raise ValueError(error_msg)
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    if save_format == "json":
+        with Path.open(output_path, "w") as f:
+            json.dump(predictions, f, indent=2)
+
+    elif save_format == "csv":
+        with Path.open(output_path, "w", newline="") as f:
+            writer = csv.DictWriter(f, fieldnames=predictions[0].keys())
+            writer.writeheader()
+            writer.writerows(predictions)


### PR DESCRIPTION
- Added predict.py (and predict.yaml) to run inference on a specified data split (train, val, test, predict)

- Saves predictions in .csv or .json format under the Hydra run directory

- Updated documentation to include prediction usage and output structure

- Refactored variable naming, output structure, and data handling.