### PR TITLE
Refactor configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ lightning-hydra-boilerplate/
 │   ├── trainer/
 │   │   ├── default.yaml
 │   ├── experiment/
-│   │   ├── exp1.yaml
+│   │   ├── example_experiment.yaml
 │   ├── train.yaml
 │   ├── eval.yaml
 │   ├── predict.yaml
@@ -66,7 +66,7 @@ poetry install
 Run the training script with the default configurations:
 
 ```bash
- poetry run python src/train.py
+ poetry run python src/train.py experiment=example_experiment
 ```
 
 This will:
@@ -80,7 +80,7 @@ This will:
 If you need to run evaluation independently on a specific checkpoint and dataset split (val or test), use the evaluation script:
 
 ```bash
-poetry run python src/eval.py data_split=test ckpt_path=/path/to/checkpoint.ckpt
+poetry run python src/eval.py experiment=example_experiment data_split=test ckpt_path=/path/to/checkpoint.ckpt
 ```
 
 ### **4️⃣ Predict Outputs**
@@ -88,7 +88,7 @@ poetry run python src/eval.py data_split=test ckpt_path=/path/to/checkpoint.ckpt
 To generate predictions from a trained model (e.g., for submission or analysis), run the predict.py script with the path to your checkpoint:
 
 ```bash
-poetry run python src/predict.py ckpt_path=/path/to/checkpoint.ckpt
+poetry run python src/predict.py experiment=example_experiment ckpt_path=/path/to/checkpoint.ckpt
 ```
 
 This will:
@@ -103,7 +103,7 @@ All experiment settings are managed with Hydra.
 You can modify the configs under configs/ or override them via CLI. For example:
 
 ```bash
- poetry run python src/train.py trainer.max_epochs=10
+ poetry run python src/train.py experiment=example_experiment trainer.max_epochs=10
 ```
 
 More info: https://hydra.cc/docs/intro/

--- a/configs/eval.yaml
+++ b/configs/eval.yaml
@@ -1,10 +1,9 @@
 defaults:
-  - model: example_model
-  - data: example_data
+  - model: ???
+  - data: ???
   - trainer: default
-  - experiment: null
+  - experiment: ???
 
-experiment_name: "eval"
 ckpt_path: ??? # User must override this
 data_split: "test" # one of: test or val
 

--- a/configs/experiment/example_experiment.yaml
+++ b/configs/experiment/example_experiment.yaml
@@ -21,4 +21,16 @@ data:
 
 # Lightning Trainer parameters
 trainer:
-  max_epochs: 1
+  max_epochs: 2
+  callbacks:
+    metric_evaluator:
+      _target_: src.callbacks.metric_evaluator.MetricEvaluator
+      metrics:
+        validation:
+          - _target_: torchmetrics.Accuracy
+            task: "multiclass"
+            num_classes: ${model.num_classes}
+        test:
+          - _target_: torchmetrics.Accuracy
+            task: "multiclass"
+            num_classes: ${model.num_classes}

--- a/configs/predict.yaml
+++ b/configs/predict.yaml
@@ -1,10 +1,9 @@
 defaults:
-  - model: example_model
-  - data: example_data
+  - model: ???
+  - data: ???
   - trainer: default
-  - experiment: null
+  - experiment: ???
 
-experiment_name: "predict"
 ckpt_path: ??? # User must override this
 data_split: "test" # one of: train, test, val, or predict
 save_format: csv # json or csv

--- a/configs/train.yaml
+++ b/configs/train.yaml
@@ -1,9 +1,9 @@
 defaults:
   - _self_
-  - model: example_model
-  - data: example_data
+  - model: ???
+  - data: ???
   - trainer: default
-  - experiment: null # Optional, can override experiment
+  - experiment: ???
 
 hydra:
   run:

--- a/configs/trainer/default.yaml
+++ b/configs/trainer/default.yaml
@@ -3,25 +3,17 @@ logger:
   _target_: lightning.pytorch.loggers.TensorBoardLogger
   save_dir: "${hydra:run.dir}/logs/"
 callbacks:
-  - _target_: lightning.pytorch.callbacks.EarlyStopping
+  early_stopping:
+    _target_: lightning.pytorch.callbacks.EarlyStopping
     monitor: "val_loss"
     mode: "min"
     patience: 3
     verbose: true
-  - _target_: lightning.pytorch.callbacks.ModelCheckpoint
+  model_checkpoint:
+    _target_: lightning.pytorch.callbacks.ModelCheckpoint
     dirpath: "${hydra:run.dir}/checkpoints"
     filename: "best-checkpoint"
     monitor: "val_loss"
     mode: "min"
     save_top_k: 1
     verbose: true
-  - _target_: src.callbacks.metric_evaluator.MetricEvaluator
-    metrics:
-      validation:
-        - _target_: torchmetrics.Accuracy
-          task: "multiclass"
-          num_classes: ${model.num_classes}
-      test:
-        - _target_: torchmetrics.Accuracy
-          task: "multiclass"
-          num_classes: ${model.num_classes}

--- a/src/eval.py
+++ b/src/eval.py
@@ -26,6 +26,11 @@ def evaluate(cfg: DictConfig) -> None:
     datamodule = instantiate(cfg.data)
     trainer_params = instantiate_recursively(cfg.trainer)
 
+    if isinstance(trainer_params, DictConfig):
+        callbacks_cfg = trainer_params.get("callbacks")
+        if isinstance(callbacks_cfg, DictConfig):
+            trainer_params.callbacks = list(callbacks_cfg.values())
+
     trainer = pl.Trainer(**trainer_params)
     datamodule.setup()
 

--- a/src/predict.py
+++ b/src/predict.py
@@ -30,6 +30,11 @@ def predict(cfg: DictConfig) -> None:
     trainer_params = instantiate_recursively(cfg.trainer)
     trainer = pl.Trainer(**trainer_params)
 
+    if isinstance(trainer_params, DictConfig):
+        callbacks_cfg = trainer_params.get("callbacks")
+        if isinstance(callbacks_cfg, DictConfig):
+            trainer_params.callbacks = list(callbacks_cfg.values())
+
     datamodule.setup()
 
     # Select appropriate dataloader

--- a/src/train.py
+++ b/src/train.py
@@ -25,6 +25,11 @@ def train(cfg: DictConfig) -> None:
     datamodule = instantiate(cfg.data)
     trainer_params = instantiate_recursively(cfg.trainer)
 
+    if isinstance(trainer_params, DictConfig):
+        callbacks_cfg = trainer_params.get("callbacks")
+        if isinstance(callbacks_cfg, DictConfig):
+            trainer_params.callbacks = list(callbacks_cfg.values())
+
     # Setup the datasets
     datamodule.setup()
     train_size = len(datamodule.train_dataloader().dataset)


### PR DESCRIPTION
Close #38 

- Move metric callback out of default config
- Update readme
- Remove default values for models and data in the entrypoint configs
- Change callbacks to dict to allow "merging" callbacks across different configs